### PR TITLE
fix(android): update nitrogen-generated code to CxxPart/JavaPart pattern

### DIFF
--- a/android/src/main/cpp/cpp-adapter.cpp
+++ b/android/src/main/cpp/cpp-adapter.cpp
@@ -1,6 +1,7 @@
-#include <jni.h>
 #include "NitroHapticsOnLoad.hpp"
+#include <fbjni/fbjni.h>
+#include <jni.h>
 
 JNIEXPORT jint JNICALL JNI_OnLoad(JavaVM* vm, void*) {
-  return margelo::nitro::haptics::initialize(vm);
+  return facebook::jni::initialize(vm, []() { margelo::nitro::haptics::registerAllNatives(); });
 }

--- a/nitrogen/generated/android/NitroHapticsOnLoad.cpp
+++ b/nitrogen/generated/android/NitroHapticsOnLoad.cpp
@@ -21,24 +21,34 @@
 namespace margelo::nitro::haptics {
 
 int initialize(JavaVM* vm) {
+  return facebook::jni::initialize(vm, []() {
+    ::margelo::nitro::haptics::registerAllNatives();
+  });
+}
+
+struct JHybridHapticsSpecImpl: public facebook::jni::JavaClass<JHybridHapticsSpecImpl, JHybridHapticsSpec::JavaPart> {
+  static auto constexpr kJavaDescriptor = "Lcom/haptics/HybridHaptics;";
+  static std::shared_ptr<JHybridHapticsSpec> create() {
+    static auto constructorFn = javaClassStatic()->getConstructor<JHybridHapticsSpecImpl::javaobject()>();
+    facebook::jni::local_ref<JHybridHapticsSpec::JavaPart> javaPart = javaClassStatic()->newObject(constructorFn);
+    return javaPart->getJHybridHapticsSpec();
+  }
+};
+
+void registerAllNatives() {
   using namespace margelo::nitro;
   using namespace margelo::nitro::haptics;
-  using namespace facebook;
 
-  return facebook::jni::initialize(vm, [] {
-    // Register native JNI methods
-    margelo::nitro::haptics::JHybridHapticsSpec::registerNatives();
+  // Register native JNI methods
+  margelo::nitro::haptics::JHybridHapticsSpec::CxxPart::registerNatives();
 
-    // Register Nitro Hybrid Objects
-    HybridObjectRegistry::registerHybridObjectConstructor(
-      "Haptics",
-      []() -> std::shared_ptr<HybridObject> {
-        static DefaultConstructableObject<JHybridHapticsSpec::javaobject> object("com/haptics/HybridHaptics");
-        auto instance = object.create();
-        return instance->cthis()->shared();
-      }
-    );
-  });
+  // Register Nitro Hybrid Objects
+  HybridObjectRegistry::registerHybridObjectConstructor(
+    "Haptics",
+    []() -> std::shared_ptr<HybridObject> {
+      return JHybridHapticsSpecImpl::create();
+    }
+  );
 }
 
 } // namespace margelo::nitro::haptics

--- a/nitrogen/generated/android/NitroHapticsOnLoad.hpp
+++ b/nitrogen/generated/android/NitroHapticsOnLoad.hpp
@@ -6,20 +6,29 @@
 ///
 
 #include <jni.h>
+#include <functional>
 #include <NitroModules/NitroDefines.hpp>
 
 namespace margelo::nitro::haptics {
 
+  [[deprecated("Use registerNatives() instead.")]]
+  int initialize(JavaVM* vm);
+
   /**
-   * Initializes the native (C++) part of NitroHaptics, and autolinks all Hybrid Objects.
-   * Call this in your `JNI_OnLoad` function (probably inside `cpp-adapter.cpp`).
+   * Register the native (C++) part of NitroHaptics, and autolinks all Hybrid Objects.
+   * Call this in your `JNI_OnLoad` function (probably inside `cpp-adapter.cpp`),
+   * inside a `facebook::jni::initialize(vm, ...)` call.
    * Example:
    * ```cpp (cpp-adapter.cpp)
    * JNIEXPORT jint JNICALL JNI_OnLoad(JavaVM* vm, void*) {
-   *   return margelo::nitro::haptics::initialize(vm);
+   *   return facebook::jni::initialize(vm, []() {
+   *     // register all NitroHaptics HybridObjects
+   *     margelo::nitro::haptics::registerAllNatives();
+   *     // any other custom registrations go here.
+   *   });
    * }
    * ```
    */
-  int initialize(JavaVM* vm);
+  void registerAllNatives();
 
 } // namespace margelo::nitro::haptics

--- a/nitrogen/generated/android/c++/JHybridHapticsSpec.cpp
+++ b/nitrogen/generated/android/c++/JHybridHapticsSpec.cpp
@@ -23,50 +23,51 @@ namespace margelo::nitro::haptics { enum class AndroidHaptics; }
 
 namespace margelo::nitro::haptics {
 
-  jni::local_ref<JHybridHapticsSpec::jhybriddata> JHybridHapticsSpec::initHybrid(jni::alias_ref<jhybridobject> jThis) {
+  std::shared_ptr<JHybridHapticsSpec> JHybridHapticsSpec::JavaPart::getJHybridHapticsSpec() {
+    auto hybridObject = JHybridObject::JavaPart::getJHybridObject();
+    auto castHybridObject = std::dynamic_pointer_cast<JHybridHapticsSpec>(hybridObject);
+    if (castHybridObject == nullptr) [[unlikely]] {
+      throw std::runtime_error("Failed to downcast JHybridObject to JHybridHapticsSpec!");
+    }
+    return castHybridObject;
+  }
+
+  jni::local_ref<JHybridHapticsSpec::CxxPart::jhybriddata> JHybridHapticsSpec::CxxPart::initHybrid(jni::alias_ref<jhybridobject> jThis) {
     return makeCxxInstance(jThis);
   }
 
-  void JHybridHapticsSpec::registerNatives() {
+  std::shared_ptr<JHybridObject> JHybridHapticsSpec::CxxPart::createHybridObject(const jni::local_ref<JHybridObject::JavaPart>& javaPart) {
+    auto castJavaPart = jni::dynamic_ref_cast<JHybridHapticsSpec::JavaPart>(javaPart);
+    if (castJavaPart == nullptr) [[unlikely]] {
+      throw std::runtime_error("Failed to cast JHybridObject::JavaPart to JHybridHapticsSpec::JavaPart!");
+    }
+    return std::make_shared<JHybridHapticsSpec>(castJavaPart);
+  }
+
+  void JHybridHapticsSpec::CxxPart::registerNatives() {
     registerHybrid({
-      makeNativeMethod("initHybrid", JHybridHapticsSpec::initHybrid),
+      makeNativeMethod("initHybrid", JHybridHapticsSpec::CxxPart::initHybrid),
     });
   }
 
-  size_t JHybridHapticsSpec::getExternalMemorySize() noexcept {
-    static const auto method = javaClassStatic()->getMethod<jlong()>("getMemorySize");
-    return method(_javaPart);
-  }
-
-  void JHybridHapticsSpec::dispose() noexcept {
-    static const auto method = javaClassStatic()->getMethod<void()>("dispose");
-    method(_javaPart);
-  }
-
-  std::string JHybridHapticsSpec::toString() {
-    static const auto method = javaClassStatic()->getMethod<jni::JString()>("toString");
-    auto javaString = method(_javaPart);
-    return javaString->toStdString();
-  }
-
   // Properties
-  
+
 
   // Methods
   void JHybridHapticsSpec::impact(ImpactFeedbackStyle style) {
-    static const auto method = javaClassStatic()->getMethod<void(jni::alias_ref<JImpactFeedbackStyle> /* style */)>("impact");
+    static const auto method = _javaPart->javaClassStatic()->getMethod<void(jni::alias_ref<JImpactFeedbackStyle> /* style */)>("impact");
     method(_javaPart, JImpactFeedbackStyle::fromCpp(style));
   }
   void JHybridHapticsSpec::notification(NotificationFeedbackType type) {
-    static const auto method = javaClassStatic()->getMethod<void(jni::alias_ref<JNotificationFeedbackType> /* type */)>("notification");
+    static const auto method = _javaPart->javaClassStatic()->getMethod<void(jni::alias_ref<JNotificationFeedbackType> /* type */)>("notification");
     method(_javaPart, JNotificationFeedbackType::fromCpp(type));
   }
   void JHybridHapticsSpec::selection() {
-    static const auto method = javaClassStatic()->getMethod<void()>("selection");
+    static const auto method = _javaPart->javaClassStatic()->getMethod<void()>("selection");
     method(_javaPart);
   }
   void JHybridHapticsSpec::performAndroidHaptics(AndroidHaptics type) {
-    static const auto method = javaClassStatic()->getMethod<void(jni::alias_ref<JAndroidHaptics> /* type */)>("performAndroidHaptics");
+    static const auto method = _javaPart->javaClassStatic()->getMethod<void(jni::alias_ref<JAndroidHaptics> /* type */)>("performAndroidHaptics");
     method(_javaPart, JAndroidHaptics::fromCpp(type));
   }
 

--- a/nitrogen/generated/android/c++/JHybridHapticsSpec.hpp
+++ b/nitrogen/generated/android/c++/JHybridHapticsSpec.hpp
@@ -18,39 +18,39 @@ namespace margelo::nitro::haptics {
 
   using namespace facebook;
 
-  class JHybridHapticsSpec: public jni::HybridClass<JHybridHapticsSpec, JHybridObject>,
-                            public virtual HybridHapticsSpec {
+  class JHybridHapticsSpec: public virtual HybridHapticsSpec, public virtual JHybridObject {
   public:
-    static auto constexpr kJavaDescriptor = "Lcom/margelo/nitro/haptics/HybridHapticsSpec;";
-    static jni::local_ref<jhybriddata> initHybrid(jni::alias_ref<jhybridobject> jThis);
-    static void registerNatives();
+    struct JavaPart: public jni::JavaClass<JavaPart, JHybridObject::JavaPart> {
+      static auto constexpr kJavaDescriptor = "Lcom/margelo/nitro/haptics/HybridHapticsSpec;";
+      std::shared_ptr<JHybridHapticsSpec> getJHybridHapticsSpec();
+    };
+    struct CxxPart: public jni::HybridClass<CxxPart, JHybridObject::CxxPart> {
+      static auto constexpr kJavaDescriptor = "Lcom/margelo/nitro/haptics/HybridHapticsSpec$CxxPart;";
+      static jni::local_ref<jhybriddata> initHybrid(jni::alias_ref<jhybridobject> jThis);
+      static void registerNatives();
+      using HybridBase::HybridBase;
+    protected:
+      std::shared_ptr<JHybridObject> createHybridObject(const jni::local_ref<JHybridObject::JavaPart>& javaPart) override;
+    };
 
-  protected:
-    // C++ constructor (called from Java via `initHybrid()`)
-    explicit JHybridHapticsSpec(jni::alias_ref<jhybridobject> jThis) :
+  public:
+    explicit JHybridHapticsSpec(const jni::local_ref<JHybridHapticsSpec::JavaPart>& javaPart):
       HybridObject(HybridHapticsSpec::TAG),
-      HybridBase(jThis),
-      _javaPart(jni::make_global(jThis)) {}
-
-  public:
+      JHybridObject(javaPart),
+      _javaPart(jni::make_global(javaPart)) {}
     ~JHybridHapticsSpec() override {
       // Hermes GC can destroy JS objects on a non-JNI Thread.
       jni::ThreadScope::WithClassLoader([&] { _javaPart.reset(); });
     }
 
   public:
-    size_t getExternalMemorySize() noexcept override;
-    void dispose() noexcept override;
-    std::string toString() override;
-
-  public:
-    inline const jni::global_ref<JHybridHapticsSpec::javaobject>& getJavaPart() const noexcept {
+    inline const jni::global_ref<JHybridHapticsSpec::JavaPart>& getJavaPart() const noexcept {
       return _javaPart;
     }
 
   public:
     // Properties
-    
+
 
   public:
     // Methods
@@ -60,9 +60,7 @@ namespace margelo::nitro::haptics {
     void performAndroidHaptics(AndroidHaptics type) override;
 
   private:
-    friend HybridBase;
-    using HybridBase::HybridBase;
-    jni::global_ref<JHybridHapticsSpec::javaobject> _javaPart;
+    jni::global_ref<JHybridHapticsSpec::JavaPart> _javaPart;
   };
 
 } // namespace margelo::nitro::haptics

--- a/nitrogen/generated/android/kotlin/com/margelo/nitro/haptics/HybridHapticsSpec.kt
+++ b/nitrogen/generated/android/kotlin/com/margelo/nitro/haptics/HybridHapticsSpec.kt
@@ -24,44 +24,41 @@ import com.margelo.nitro.core.HybridObject
   "LocalVariableName", "PropertyName", "PrivatePropertyName", "FunctionName"
 )
 abstract class HybridHapticsSpec: HybridObject() {
+  // Properties
+
+
+  // Methods
   @DoNotStrip
-  private var mHybridData: HybridData = initHybrid()
+  @Keep
+  abstract fun impact(style: ImpactFeedbackStyle): Unit
 
-  init {
-    super.updateNative(mHybridData)
-  }
+  @DoNotStrip
+  @Keep
+  abstract fun notification(type: NotificationFeedbackType): Unit
 
-  override fun updateNative(hybridData: HybridData) {
-    mHybridData = hybridData
-    super.updateNative(hybridData)
-  }
+  @DoNotStrip
+  @Keep
+  abstract fun selection(): Unit
+
+  @DoNotStrip
+  @Keep
+  abstract fun performAndroidHaptics(type: AndroidHaptics): Unit
 
   // Default implementation of `HybridObject.toString()`
   override fun toString(): String {
     return "[HybridObject Haptics]"
   }
 
-  // Properties
-  
-
-  // Methods
+  // C++ backing class
   @DoNotStrip
   @Keep
-  abstract fun impact(style: ImpactFeedbackStyle): Unit
-  
-  @DoNotStrip
-  @Keep
-  abstract fun notification(type: NotificationFeedbackType): Unit
-  
-  @DoNotStrip
-  @Keep
-  abstract fun selection(): Unit
-  
-  @DoNotStrip
-  @Keep
-  abstract fun performAndroidHaptics(type: AndroidHaptics): Unit
-
-  private external fun initHybrid(): HybridData
+  protected open class CxxPart(javaPart: HybridHapticsSpec): HybridObject.CxxPart(javaPart) {
+    // C++ JHybridHapticsSpec::CxxPart::initHybrid(...)
+    external override fun initHybrid(): HybridData
+  }
+  override fun createCxxPart(): CxxPart {
+    return CxxPart(this)
+  }
 
   companion object {
     protected const val TAG = "HybridHapticsSpec"


### PR DESCRIPTION
## Summary

- Updates the nitrogen-generated Android code to use the newer Nitro Modules API with `CxxPart`/`JavaPart` inner classes instead of the legacy `HybridClass` pattern
- Fixes Android build compatibility with recent versions of `react-native-nitro-modules` (0.35.0)
- Adds `registerAllNatives()` entry point and deprecates the old `initialize()` function

## Changes

| File | Description |
|------|-------------|
| `HybridHapticsSpec.kt` | Replace manual `HybridData`/`initHybrid` with `CxxPart` inner class pattern |
| `JHybridHapticsSpec.hpp` | Migrate from `HybridClass` inheritance to `JavaPart`/`CxxPart` structs |
| `JHybridHapticsSpec.cpp` | Update JNI method implementations to use new `_javaPart->javaClassStatic()` |
| `NitroHapticsOnLoad.hpp` | Add `registerAllNatives()`, deprecate `initialize()` |
| `NitroHapticsOnLoad.cpp` | Add `JHybridHapticsSpecImpl` factory, refactor registration |
| `cpp-adapter.cpp` | Use `facebook::jni::initialize` with `registerAllNatives()` |

## Context

The current nitrogen-generated code uses an older Nitro Modules pattern that is incompatible with `react-native-nitro-modules` v0.22+. The new `CxxPart`/`JavaPart` pattern is the current standard used by the nitrogen code generator.

## Test plan

- [ ] Verify Android build succeeds
- [ ] Test haptic feedback on Android device (impact, notification, selection)
- [ ] Verify iOS is unaffected (no iOS changes)