### PR TITLE
fix(android): use decorView for performAndroidHaptics

### DIFF
--- a/android/src/main/java/com/haptics/HybridHaptics.kt
+++ b/android/src/main/java/com/haptics/HybridHaptics.kt
@@ -132,8 +132,8 @@ class HybridHaptics: HybridHapticsSpec() {
       throw Error("Haptic feedback type '$type' not supported.")
     }
     
-    val view: View = View(NitroModules.applicationContext)
-    view?.performHapticFeedback(feedbackType)
+    val decorView = NitroModules.applicationContext?.currentActivity?.window?.decorView
+    decorView?.performHapticFeedback(feedbackType)
   }
   
   @DoNotStrip


### PR DESCRIPTION
Fixes #18

`performAndroidHaptics` was calling `performHapticFeedback` on a freshly constructed `View(context)` that was never attached to a window. Android silently ignores haptic feedback on detached views.

Fix uses the activity's `decorView` which is always attached and has haptic feedback enabled by default.