### PR TITLE
fix(ios): dispatch haptic feedback generators on main thread and reuse them

### DIFF
--- a/ios/HybridHaptics.swift
+++ b/ios/HybridHaptics.swift
@@ -11,24 +11,46 @@ import NitroModules
 
 /**
  * Implement `HybridHapticsSpec` so we can expose this Swift class to JS.
+ *
+ * Nitro invokes these methods synchronously on the JS thread, but
+ * UIFeedbackGenerator is main-thread-only UIKit API. Every call is bounced to
+ * the main queue, and generators are reused between calls so the underlying
+ * haptic engine is not activated/deactivated on every event.
  */
 class HybridHaptics : HybridHapticsSpec {
+  private var impactGenerators: [UIImpactFeedbackGenerator.FeedbackStyle: UIImpactFeedbackGenerator] = [:]
+  private var notificationGenerator: UINotificationFeedbackGenerator? = nil
+  private var selectionGenerator: UISelectionFeedbackGenerator? = nil
+
   func impact(style: ImpactFeedbackStyle) throws -> Void {
-    let generator = UIImpactFeedbackGenerator(style: style.toUIImpactFeedbackType())
-    generator.prepare()
-    generator.impactOccurred()
+    let uiStyle = style.toUIImpactFeedbackType()
+    DispatchQueue.main.async {
+      let generator: UIImpactFeedbackGenerator
+      if let cached = self.impactGenerators[uiStyle] {
+        generator = cached
+      } else {
+        generator = UIImpactFeedbackGenerator(style: uiStyle)
+        self.impactGenerators[uiStyle] = generator
+      }
+      generator.impactOccurred()
+    }
   }
 
   func notification(type: NotificationFeedbackType) throws -> Void {
-    let generator = UINotificationFeedbackGenerator()
-    generator.prepare()
-    generator.notificationOccurred(type.toUINotificationFeedbackType())
+    let uiType = type.toUINotificationFeedbackType()
+    DispatchQueue.main.async {
+      let generator = self.notificationGenerator ?? UINotificationFeedbackGenerator()
+      self.notificationGenerator = generator
+      generator.notificationOccurred(uiType)
+    }
   }
 
   func selection() throws -> Void {
-    let generator = UISelectionFeedbackGenerator()
-    generator.prepare()
-    generator.selectionChanged()
+    DispatchQueue.main.async {
+      let generator = self.selectionGenerator ?? UISelectionFeedbackGenerator()
+      self.selectionGenerator = generator
+      generator.selectionChanged()
+    }
   }
 
   func performAndroidHaptics(type: AndroidHaptics) throws -> Void {


### PR DESCRIPTION
### Problem

`HybridHaptics.swift`'s `impact`/`notification`/`selection` create and fire
`UIFeedbackGenerator` subclasses directly on whatever thread calls them. Nitro modules run
synchronously on the JS thread, so these UIKit calls (main-thread-only) execute off the main
thread. This causes Main Thread Checker warnings and, under production load, an intermittent
crash in libdispatch (`dispatch_group_leave` inside `_dispatch_block_async_invoke2`) — UIKit's
`_UIFeedbackEngine` races itself scheduling/cancelling its idle-deactivation block on the main
queue from a background thread. Full write-up: #23.

Creating a new generator per call instead of reusing one also means the haptic engine
activates/deactivates far more often than necessary, widening that race window (Apple's docs
recommend keeping generators alive and reusing them).

### Fix

- Bounce every generator call to `DispatchQueue.main.async`.
- Cache one generator per impact style, and one each for notification/selection, reused across
  calls instead of allocate-fire-deallocate per event.

### Testing

- Debug build with Main Thread Checker enabled: warning no longer fires on haptic calls.
- Verified haptics still fire correctly on-device (impact/notification/selection) after the change.
- Running in production for several days with no regressions and no recurrence of the crash so far.

### Notes

`performAndroidHaptics` is unchanged (Android-only code path, throws on iOS as before).

Closes #23